### PR TITLE
Implement overlay and top level dialogs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  layout -> { turbo_frame_request? ? 'turbo' : 'application' }
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -14,14 +14,20 @@
   <div class="m-4">
     Main Content
   </div>
-  <ul class="flex flex-row flex-wrap gap-4 m-4">
-    <% (1.. 30).to_a.sample.times do |n| %>
-      <a href="/dialog" data-turbo-frame="dialog" class="h-40 w-40 border-2 bg-slate-400/80 cursor-pointer">&nbsp;</a>
+  <ul id="main-content-list" class="flex flex-row flex-wrap gap-4 m-4" data-turbo-permanent>
+    <% (99.. 200).to_a.sample.times do |n| %>
+      <a
+        href="/dialog"
+        data-turbo-action="advance"
+        data-turbo-frame="dialog"
+        class="h-40 w-40 border-2 bg-slate-400/80 cursor-pointer"
+      >
+        &nbsp;
+      </a>
     <% end %>
   </ul>
 <% end %>
 
 <% content_for :dialog do %>
-  <%# ooooh.... could it here? %>
   <%= turbo_frame_tag "dialog" %>
 <% end %>

--- a/app/views/dashboard/show.html.erb
+++ b/app/views/dashboard/show.html.erb
@@ -1,6 +1,16 @@
-<%# well, yea this obviously has to be here.. %>
-<%= turbo_frame_tag "dialog" do %>
-  <a href="/" data-action="click->dialog#close" data-turbo-frame="dialog" class="cursor-pointer">
-    this is dialog content
-  </a>
+<% content_for :dialog do %>
+  <%= turbo_frame_tag "dialog" do %>
+    <div
+      class="absolute inset-0 h-lvh w-lvw bg-gray-500 bg-opacity-75 backdrop-blur-sm"
+      data-action="click->dialog#close"
+      data-dialog-target="content"
+      data-dialog-close-url-param="/"
+      data-dialog-close-turbo-frame-param="_top"
+      data-dialog-close-turbo-action-param="advance"
+    >
+      <div class="h-fit w-fit m-auto cursor-pointer">
+        this is dialog content
+      </div>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,16 +20,15 @@
   </head>
 
   <body class="flex flex-row h-lvh w-lvw">
-    <sidebar class="basis-1/4 grow-0 shrink-0 bg-red-200">
+    <sidebar class="basis-1/4 grow-0 shrink-0 bg-red-200 overflow-y-auto">
       <%= yield :sidebar %>
     </sidebar>
 
-    <main class="grow bg-blue-200">
+    <main class="grow bg-blue-200 overflow-y-auto">
       <%= yield :main %>
     </main>
 
-    <dialog data-controller="dialog" class="fixed inset-0 h-lvh w-lvw max-h-full max-w-full bg-gray-500 bg-opacity-75 backdrop-blur-sm">
-      <%# Let's play the game "where to hide `turbo_frame_tag "dialog"` %>
+    <dialog id="global-dialog" data-controller="dialog" class="z-40 fixed isolate inset-0 h-lvh w-lvw max-h-full max-w-full bg-transparent">
       <%= yield :dialog %>
     </dialog>
   </body>

--- a/app/views/layouts/turbo.html.erb
+++ b/app/views/layouts/turbo.html.erb
@@ -1,0 +1,11 @@
+<head>
+  <%= yield :head %>
+</head>
+
+<body>
+  <%= yield :sidebar %>
+
+  <%= yield :main %>
+
+  <%= yield :dialog %>
+</body>


### PR DESCRIPTION
This PR allows users to open a resource in an overlay dialog (with all accessibility features baked in) as well as navigate to the resource directly via URL and still be able to close it as if they'd been on the main page all along.